### PR TITLE
Implement server base path configuration for reverse proxies

### DIFF
--- a/server.example.conf
+++ b/server.example.conf
@@ -1,6 +1,7 @@
 [Server]
 port = 9001
 staticDir = "./static"
+basePath = "/"
 adminPassword = "1337"
 pauseOnChange = true
 pauseOnLeave = false

--- a/src/server/config.nim
+++ b/src/server/config.nim
@@ -4,6 +4,7 @@ type
   Config* = object
     port*: int
     staticDir*: string
+    basePath*: string
     adminPassword*: string
     pauseOnChange*: bool
     pauseOnLeave*: bool
@@ -14,6 +15,7 @@ proc getConfig*(): Config =
   Config(
     port: cfg.get("Server", "port", 9001),
     staticDir: cfg.get("Server", "staticDir", "./static"),
+    basePath: cfg.get("Server", "basePath", "/"),
     adminPassword: cfg.get("Server", "adminPassword", "1337"),
     pauseOnChange: cfg.get("Server", "pauseOnChange", true),
     pauseOnLeave: cfg.get("Server", "pauseOnLeave", false)

--- a/static/client.html
+++ b/static/client.html
@@ -1,6 +1,6 @@
 <html>
   <head>
-    <link rel="stylesheet" href="style.css" />
+    <link rel="stylesheet" href="./style.css" />
     <link rel="stylesheet" href="https://cdn.plyr.io/3.7.2/plyr.css" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Kinoplex Web</title>
@@ -10,6 +10,6 @@
     <div id="ROOT"></div>
     <script src="https://cdn.jsdelivr.net/npm/hls.js@latest"></script>
     <script src="https://cdn.plyr.io/3.7.2/plyr.js"></script>
-    <script src="client.js"></script>
+    <script src="./client.js"></script>
   </body>
 </html>


### PR DESCRIPTION
Makes it possible to configure the access point at a subpath (i.e `/kino/`, `/kino/plex/`) to facilitate reverse proxying.